### PR TITLE
Fix .gitignore merge conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,13 @@ Icon?
 .Spotlight-V100
 .Trashes
 
+# Swift Package Manager
+/.build
+/Packages
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+
 # Xcode
 build/
 DerivedData/


### PR DESCRIPTION
## Summary
- merge missing SwiftPM ignore rules into `.gitignore`

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6849777c4fb48325afadf4108dfaf0c9